### PR TITLE
Update to Spigot 1.19.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
-# Project exclude paths
+# Output
 /target/
+
+# Test MC server
+/testserver/
+
+# IntelliJ
+/.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,40 @@
 # Test MC server
 /testserver/
 
-# IntelliJ
-/.idea/
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.ear
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+# Eclipse
+.classpath
+.project
+.settings/
+
+# Intellij
+.idea/
+*.iml
+*.iws
+
+# Mac
+.DS_Store
+
+# Maven
+log/
+target/
+
+# Inclusions
+!lib/**
+
+# Compiled Files
+*.class
+bin/
+build/
+/bin1/
+java/build/**

--- a/pom.xml
+++ b/pom.xml
@@ -16,27 +16,41 @@
 
     <repositories>
         <!-- This adds the Spigot Maven repository to the build -->
-        <!--<repository>
+        <repository>
             <id>spigot-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
-        </repository>-->
+        </repository>
+
+        <repository>
+            <id>papermc</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
     </repositories>
 
     <dependencies>
-        <!-- NOTE: Comment or uncomment whether using offline or maven repo for spigot API! -->
-        <!-- This adds the Spigot API artifact to the build -->
-<!--        <dependency>
+        <!-- MockBukkit must be listed above Spigot as it depends on Paper. Builds in test will fail otherwise.
+        See https://github.com/MockBukkit/MockBukkit/issues/462#issuecomment-1156574495 -->
+        <!-- https://mvnrepository.com/artifact/com.github.seeseemelk/MockBukkit-v1.19 -->
+        <dependency>
+            <groupId>com.github.seeseemelk</groupId>
+            <artifactId>MockBukkit-v1.19</artifactId>
+            <version>2.110.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- NOTE: Comment or uncomment whether using local or maven repo for spigot API! -->
+        <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.18.1-R0.1-shaded-SNAPSHOT</version>
-            <scope>provided</scope>
-        </dependency>-->
+            <version>1.19.1-R0.1-SNAPSHOT</version>
+            <classifier>shaded</classifier>
+        </dependency>
 
         <!-- Testing frameworks -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.8.2</version>
+            <version>5.9.0</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->
@@ -45,12 +59,6 @@
             <artifactId>mockito-core</artifactId>
             <version>4.2.0</version>
             <scope>test</scope>
-        </dependency>
-        <!-- https://mvnrepository.com/artifact/com.github.seeseemelk/MockBukkit-v1.18 -->
-        <dependency>
-            <groupId>com.github.seeseemelk</groupId>
-            <artifactId>MockBukkit-v1.18</artifactId>
-            <version>1.15.0</version>
         </dependency>
     </dependencies>
 

--- a/src/test/java/tests/gametests/TagGameTests.java
+++ b/src/test/java/tests/gametests/TagGameTests.java
@@ -4,7 +4,7 @@ import be.seeseemelk.mockbukkit.entity.PlayerMock;
 import io.benlewis.tagminigame.game.data.DataPlayer;
 import io.benlewis.tagminigame.game.tag.TagGame;
 import io.benlewis.tagminigame.game.tag.TagPlayer;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.bukkit.entity.Player;
 import org.junit.jupiter.api.Test;
 import tests.MockBukkitTests;


### PR DESCRIPTION
Update native spigot version to 1.19.1.
Update MockBukkit to 2.x.x, which is now based on Paper.
Improved .gitignore to ignore common Java, IntelliJ and testserver files.